### PR TITLE
let user store objects in the session

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Dancer-Session-Cookie
 
 {{$NEXT}}
 
+    [CHANGED]
+
+    - Requires Session::Storage::Secure 0.010 to allow storing objects,
+      which is specially relevant for JSON::bool data.
+
 0.22      2013-05-31 23:38:07 America/New_York
 
     [CHANGED]

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use base 'Dancer::Session::Abstract';
 
-use Session::Storage::Secure 0.007;
+use Session::Storage::Secure 0.010;
 use Crypt::CBC;
 use String::CRC32;
 use Crypt::Rijndael;
@@ -45,6 +45,8 @@ sub init {
     $STORE = Session::Storage::Secure->new(
         secret_key => $key,
         ( $duration ? ( default_duration => $duration ) : () ),
+        sereal_encoder_options => { snappy => 1, stringify_unknown => 1 },
+        sereal_decoder_options => { validate_utf8 => 1 },
     );
 }
 


### PR DESCRIPTION
Hi there!

I've been talking to @dagolden regarding storing objects in sessions, which ended up becoming an option in Session::Storage::Secure 0.010. This patch attempts to push this update to Dancer::Session::Cookie by creating the Sereal Encoder/Decoder without the 'croak_on_blessed' option.

By default, Session::Storage::Secure does not allow storing objects due to concerns of action-at-a-distance. This is because, as Sereal::Encoder's documentation puts it, blessed references can mean executing a destructor on a remote system or generally executing code based on data. In a web application, however, it is very common to store JSON data in sessions (like when handling oauth from third-party providers). The Perl implementation of JSON creates thin "JSON::bool" objects to make the 1/true 0/false relationship between JSON data and Perl data structures, but you can't store it in Dancer::Session::Cookie because it doesn't allow objects. Besides, since session handling is performed by the developer, it should be the developer's responsibility to either store objects or not on the session structure.

Hopefully, if accepted, this patch will fix the issues above :)

Please let me know if you have any questions, issues or comments, of if there is anyway I can improve it so it is accepted upstream. Thanks!
