### PR TITLE
Mention max cookie size in docs

### DIFF
--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -219,6 +219,11 @@ module uses cryptography to ensure integrity and also secrecy. The
 data your application stores in sessions is completely protected from
 both tampering and analysis on the client-side.
 
+Do be aware that browsers limit the size of individual cookies, so this method
+is not suitable if you wish to store a large amount of data.  Browsers typically
+limit the size of a cookie to 4KB, but that includes the space taken to store
+the cookie's name, expiration and other attributes as well as its content.
+
 =head1 CONFIGURATION
 
 The setting B<session> should be set to C<cookie> in order to use this session


### PR DESCRIPTION
Closes #2 - mentioning the max cookie size.

Sensible idea to draw people's attention to the fact that cookies can't be too big.

Opinion: should we have the code work out the size of the cookie when flushing, and if it's > 4KB, throw a warning to the logs that it's likely to be rejected by browsers, to help developers debugging issues?  Or is this sufficient?
