### PR TITLE
Remove the usage of Test::WWW::Mechanize::PSGI

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for Dancer-Session-Cookie
  [BUG FIXES]
 
  [DOCUMENTATION]
+ - Document the 'session_expires' setting.
 
  [ENHANCEMENTS]
 

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for Dancer-Session-Cookie
 
  [DOCUMENTATION]
  - Document the 'session_expires' setting.
+ - Warn about maximal cookie size. (GH#2 David Precious)
 
  [ENHANCEMENTS]
 

--- a/Changes
+++ b/Changes
@@ -7,12 +7,18 @@ Revision history for Dancer-Session-Cookie
 
  [DOCUMENTATION]
 
- [MISC]
- - Move tests from Test::TCP to Test::WWW::Mechanize::PSGI.
+ [ENHANCEMENTS]
 
  [NEW FEATURES]
 
  [STATISTICS]
+
+0.25 2014-08-04
+ [MISC]
+ - Move tests from Test::TCP to Test::WWW::Mechanize::PSGI.
+
+ [STATISTICS]
+ - code churn: 5 files changed, 138 insertions(+), 174 deletions(-)
 
 0.24 2014-07-29
  [MISC]
@@ -67,8 +73,8 @@ Revision history for Dancer-Session-Cookie
  - Fix for Dancer > v1.3012 
  - Add support for session_secure to serve https only cookies. 
  - Add missing MYMETA.yml 
- - Make Dancer::Session::Cookie honor the session_name setting		
-   added to Dancer::Session::Abstract
+ - Make Dancer::Session::Cookie honor the session_name setting		   
+      added to Dancer::Session::Abstract
  - Add session_cookie_path to control the path of the cookie.
 
 0.13 2010-11-28T17:19:58Z

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -213,10 +213,15 @@ A mandatory setting is needed as well: B<session_cookie_key>, which should
 contain a random string of at least 16 characters (shorter keys are
 not cryptographically strong using AES in CBC mode).
 
+The optional B<session_expires> setting can also be passed, 
+which will provide the duration time of the cookie. If it's not present, the
+cookie won't have an expiration value.
+
 Here is an example configuration to use in your F<config.yml>:
 
     session: "cookie"
     session_cookie_key: "kjsdf07234hjf0sdkflj12*&(@*jk"
+    session_expires: 1 hour
 
 Compromising B<session_cookie_key> will disclose session data to
 clients and proxies or eavesdroppers and will also allow tampering,

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -204,6 +204,11 @@ module uses cryptography to ensure integrity and also secrecy. The
 data your application stores in sessions is completely protected from
 both tampering and analysis on the client-side.
 
+Do be aware that browsers limit the size of individual cookies, so this method
+is not suitable if you wish to store a large amount of data.  Browsers typically
+limit the size of a cookie to 4KB, but that includes the space taken to store
+the cookie's name, expiration and other attributes as well as its content.
+
 =head1 CONFIGURATION
 
 The setting B<session> should be set to C<cookie> in order to use this session

--- a/t/06-redirect.t
+++ b/t/06-redirect.t
@@ -5,13 +5,19 @@ use warnings;
 
 use Test::More import => ["!pass"];
 
-plan skip_all => "Test::WWW::Mechanize::PSGI required" unless eval {
-    require Test::WWW::Mechanize::PSGI;
+plan skip_all => "Plack::Test required" unless eval {
+    require Plack::Test;
 };
 
-my $app = Test::WWW::Mechanize::PSGI->new( app => do {
-    package MyApp;
+plan skip_all => "HTTP::Cookies required" unless eval {
+    require HTTP::Cookies;
+};
 
+# available from Plack::Test
+require HTTP::Request::Common;
+
+{
+    package MyApp;
     use Dancer ':tests', ':syntax';
 
     set apphandler  => 'PSGI';
@@ -42,12 +48,32 @@ my $app = Test::WWW::Mechanize::PSGI->new( app => do {
         session 'login' => undef;
         return 'login page';
     };
+}
 
-    dance;
-});
+my $app = Plack::Test->create( MyApp->dance );
+my $jar = HTTP::Cookies->new();
+my $url = 'http://localhost';
+my $redir_url;
 
-$app->get_ok( '/' );
-$app->content_is( 'login page' );
+{
+    my $res = $app->request( HTTP::Request::Common::GET("$url/") );
+    ok( $res->is_redirect, 'GET / redirects' );
+    is(
+        $redir_url = $res->header('Location'),
+        'http://localhost/login/',
+        'Redirects to /login/',
+    );
+
+    $jar->extract_cookies($res);
+}
+
+{
+    my $req = HTTP::Request::Common::GET($redir_url);
+    $jar->add_cookie_header($req);
+
+    my $res = $app->request($req);
+    ok( $res->is_success, 'GET / successful' );
+    is( $res->content, 'login page', 'Correct login page content' );
+}
 
 done_testing;
-

--- a/t/redirect-session-dancer.t
+++ b/t/redirect-session-dancer.t
@@ -5,43 +5,71 @@ use warnings;
 
 use Test::More import => ["!pass"];
 
-plan skip_all => "Test::WWW::Mechanize::PSGI required" unless eval {
-    require Test::WWW::Mechanize::PSGI;
+plan skip_all => "Plack::Test required" unless eval {
+    require Plack::Test;
 };
 
-my $app = create_app();
+plan skip_all => "HTTP::Cookies required" unless eval {
+    require HTTP::Cookies;
+};
 
-$app->get_ok( '/xxx' );
-$app->content_is( '/xxx' );
+# available from Plack::Test
+require HTTP::Request::Common;
+
+sub mk_request {
+    my ( $app, $jar, $url, $check_ok ) = @_;
+    defined $check_ok or $check_ok = 1;
+    my $req = HTTP::Request::Common::GET("http://localhost$url");
+    $jar->add_cookie_header($req);
+    my $res = $app->request($req);
+    $jar->extract_cookies($res);
+    $check_ok and ok( $res->is_success, "GET $url" );
+    return $res;
+}
+
+my $app = Plack::Test->create( create_app() );
+my $jar = HTTP::Cookies->new;
+my $redir_url;
+
+{
+    my $res = mk_request( $app, $jar, '/xxx', 0 );
+    ok( $res->is_redirect, 'GET /xxx redirects' );
+    is(
+        $res->header('Location'),
+        'http://localhost/b',
+        'Redirects to /b',
+    );
+}
+
+{
+    my $res = mk_request( $app, $jar, '/b' );
+    is( $res->content, '/xxx', 'Correct content' );
+}
 
 sub create_app {
-    my $app = Test::WWW::Mechanize::PSGI->new( app => do {
     package MyApp;
+    use Dancer ':tests', ':syntax';
 
-        use Dancer ':tests', ':syntax';
+    set apphandler          => 'PSGI';
+    set appdir              => '';          # quiet warnings not having an appdir
+    set access_log          => 0;           # quiet startup banner
 
-        set apphandler          => 'PSGI';
-        set appdir              => '';          # quiet warnings not having an appdir
-        set access_log          => 0;           # quiet startup banner
+    set session_cookie_key  => "John has a long mustache";
+    set session             => "cookie";
 
-        set session_cookie_key  => "John has a long mustache";
-        set session             => "cookie";
+    get '/b' => sub {
+        return session('abc');
+    };
 
-        get '/b' => sub {
-            return session('abc');
-        };
+    hook 'before' => sub {
+        my $a = request->path_info;
+        if ( not request->path_info =~ m{^/(a|b|c)} ){
+            session abc => $a ;
+            return redirect '/b';
+        }
+    };
 
-        hook 'before' => sub {
-            my $a = request->path_info;
-            if ( not request->path_info =~ m{^/(a|b|c)} ){
-                session abc => $a ;
-                return redirect '/b';
-            }
-        };
-
-        dance;
-    }
-)}
+    dance;
+}
 
 done_testing;
-


### PR DESCRIPTION
`Test::WWW::Mechanize::PSGI` uses `Test::WWW::Mechanize`, which uses
`WWW::Mechanize`. The tests in `WWW::Mechanize` create a server which
it then tries to connect to. This sometimes works and sometimes
doesn't - similar to older versions of `Test::TCP`.

When installing this module from scratch, we encounter multiple
times of this installation hanging because of the `WWW::Mechanize`
tests. Changing to using `HTTP::Request`/`HTTP::Response` directly
solves this problem.