### PR TITLE
Add initial Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+
+branches:
+    except:
+        - releases
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+
+install:
+    - dzil authordeps --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test --author --release

--- a/Changes
+++ b/Changes
@@ -1,8 +1,6 @@
 Revision history for Dancer-Session-Cookie
 
 {{$NEXT}}
-    - Remode  'README.pod' from distribution. [GH#6]
-
   [ API CHANGES ]
 
   [ BUG FIXES ]
@@ -14,6 +12,12 @@ Revision history for Dancer-Session-Cookie
   [ NEW FEATURES ]
 
   [ STATISTICS ]
+
+0.27 2015-09-23
+  - Remode  'README.pod' from distribution. [GH#6]
+
+  [ STATISTICS ]
+    - code churn: 4 files changed, 62 insertions(+), 126 deletions(-)
 
 0.26 2015-09-10
   - Switch Test::WWW::Mechanize::PSGI for raw HTTP::Request/Response.
@@ -86,7 +90,7 @@ Revision history for Dancer-Session-Cookie
     - Fix for Dancer > v1.3012 
     - Add support for session_secure to serve https only cookies. 
     - Add missing MYMETA.yml 
-    - Make Dancer::Session::Cookie honor the session_name setting	 
+    - Make Dancer::Session::Cookie honor the session_name setting      
       added to Dancer::Session::Abstract
     - Add session_cookie_path to control the path of the cookie.
 


### PR DESCRIPTION
This patch adds the ability to build and test `Dancer::Session::Cookie` on Travis-CI.  The reason only Perl 5.22 onwards is used is because there is a dependency on `List::Lazy` which requires a minimum Perl version of 5.22 (otherwise the build barfs).  The dependency installation step also doesn't use the `--no-skip-satisfied` option to `cpanm` since `IPC::System::Simple` doesn't seem to want to build on Travis.  Perhaps one could get around that by not running the tests on the dependencies, but I tend not to like doing that, hence the patch's current form.

The fact that `List::Lazy` requires 5.22+ raises an interesting question: what should the minimum Perl version for this dist?  The minimum required Perl version according to syntax is 5.6.  Perhaps it's possible to install this module on a 5.6 system, however one can't test it on a 5.6 system.  Is it possible (or even sensible) to separate the Perl version restrictions in `Dist::Zilla`: i.e. have a minimum required Perl version for installation and another for testing?

Also, I'm not 100% certain as to why this PR wants to include the most recent commit on the master branch (3ef091f).  I hope this doesn't cause you any problems.  If it *does* cause you problems, please let me know and I'll see if I can fix the issue (I've already tried fixing the issue by using a new branch, but that didn't help...).  Also, if you have any questions or comments concerning this PR, please don't hesitate to contact me; if anything needs changing just let me know and I'll update and resubmit as necessary.