### PR TITLE
Minor doc fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,6 @@
 Revision history for Dancer-Session-Cookie
 
 {{$NEXT}}
-    - Remode  'README.pod' from distribution. [GH#6]
-
   [ API CHANGES ]
 
   [ BUG FIXES ]
@@ -14,6 +12,12 @@ Revision history for Dancer-Session-Cookie
   [ NEW FEATURES ]
 
   [ STATISTICS ]
+
+0.27 2015-09-23
+  - Remode  'README.pod' from distribution. [GH#6]
+
+  [ STATISTICS ]
+    - code churn: 4 files changed, 62 insertions(+), 126 deletions(-)
 
 0.26 2015-09-10
   - Switch Test::WWW::Mechanize::PSGI for raw HTTP::Request/Response.
@@ -86,7 +90,7 @@ Revision history for Dancer-Session-Cookie
     - Fix for Dancer > v1.3012 
     - Add support for session_secure to serve https only cookies. 
     - Add missing MYMETA.yml 
-    - Make Dancer::Session::Cookie honor the session_name setting	 
+    - Make Dancer::Session::Cookie honor the session_name setting      
       added to Dancer::Session::Abstract
     - Add session_cookie_path to control the path of the cookie.
 

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -194,12 +194,12 @@ Your F<config.yml>:
 =head1 DESCRIPTION
 
 This module implements a session engine for sessions stored entirely
-in cookies. Usually only B<session id> is stored in cookies and
+in cookies. Usually only the B<session id> is stored in cookies and
 the session data itself is saved in some external storage, e.g.
-database. This module allows to avoid using external storage at
+a database. This module allows you to avoid using external storage at
 all.
 
-Since server cannot trust any data returned by client in cookies, this
+Since a server cannot trust any data returned by clients in cookies, this
 module uses cryptography to ensure integrity and also secrecy. The
 data your application stores in sessions is completely protected from
 both tampering and analysis on the client-side.
@@ -214,11 +214,11 @@ the cookie's name, expiration and other attributes as well as its content.
 The setting B<session> should be set to C<cookie> in order to use this session
 engine in a Dancer application. See L<Dancer::Config>.
 
-A mandatory setting is needed as well: B<session_cookie_key>, which should
+Another setting is also required: B<session_cookie_key>, which should
 contain a random string of at least 16 characters (shorter keys are
 not cryptographically strong using AES in CBC mode).
 
-The optional B<session_expires> setting can also be passed, 
+The optional B<session_expires> setting can also be passed,
 which will provide the duration time of the cookie. If it's not present, the
 cookie won't have an expiration value.
 

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -239,7 +239,7 @@ invalidation of all sessions issued with the old value of key.
 B<session_cookie_path> can be used to control the path of the session
 cookie.  The default is C</>.
 
-The global B<session_secure> setting is honoured and a secure (https
+The global B<session_secure> setting is honored and a secure (https
 only) cookie will be used if set.
 
 =head1 DEPENDENCY

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -237,7 +237,7 @@ Also, changing B<session_cookie_key> will have an effect of immediate
 invalidation of all sessions issued with the old value of key.
 
 B<session_cookie_path> can be used to control the path of the session
-cookie.  The default is /.
+cookie.  The default is C</>.
 
 The global B<session_secure> setting is honoured and a secure (https
 only) cookie will be used if set.


### PR DESCRIPTION
This PR improves sentence flow in the documentation a bit and fixes other minor issues.  I've split up the commits so that they can be cherry-picked if so desired.  For instance, I've made the assumption that American spelling should be used (as is often the case with technical documentation); however, I suspect you might have wanted the Canadian spelling (which seems to often follow the British spelling conventions), hence cherry-picking might be the best thing.  If you want these commits rolled into one commit so that the history is nicer, I don't have a problem with doing that and can resubmit the PR.