### PR TITLE
Set minimum Perl version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ requires "Storable" => "0";
 requires "String::CRC32" => "0";
 requires "Time::Duration::Parse" => "0";
 requires "base" => "0";
+requires "perl" => "5.008";
 requires "strict" => "0";
 requires "warnings" => "0";
 
@@ -31,7 +32,6 @@ on 'test' => sub {
   requires "Test::More" => "0.96";
   requires "Test::NoWarnings" => "0";
   requires "Test::Requires" => "0";
-  requires "perl" => "5.006";
 };
 
 on 'test' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,9 @@ copyright_holder = Alex Kapranoff
 -remove=ReadmeFromPod
 NextVersion::Semantic.format=%d.%02d
 
+[Prereqs]
+perl = 5.008
+
 [Prereqs / TestRequires]
 Plack                 = 1.0029
 HTTP::Cookies         = 0

--- a/lib/Dancer/Session/Cookie.pm
+++ b/lib/Dancer/Session/Cookie.pm
@@ -4,6 +4,7 @@ use warnings;
 # ABSTRACT: Encrypted cookie-based session backend for Dancer
 # VERSION
 
+use 5.008;
 use base 'Dancer::Session::Abstract';
 
 use Session::Storage::Secure 0.010;


### PR DESCRIPTION
I'm not 100% if this is the correct way to set the minimum Perl version for this dist.  Sometimes Dist::Zilla power users have other ways of setting such parameters, so I'm unsure if I've got this right.  Nevertheless, this PR can be considered as a discussion starter.

The initial impetus for this PR is from [CPANTS](https://cpants.cpanauthors.org/dist/Dancer-Session-Cookie), which mentions that the minimum Perl version is missing for this dist.

I've chosen Perl 5.8 as the minimum version because the prereqs of this dist don't seem to be able to build and install under 5.6.2.  Under 5.8.9 everything builds fine and the dist's tests run without problems (when building and testing the source of the current dist version from CPAN (0.28)).

As with all my PRs, this is submitted in the hope that it is useful and if you need anything changed, please just let me know and I'll update the PR and resubmit as necessary.