### PR TITLE
Add Travis and AppVeyor badges to README

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,10 @@ copyright_holder = Alex Kapranoff
 -remove=ReadmeFromPod
 NextVersion::Semantic.format=%d.%02d
 
+[GitHubREADME::Badge]
+badges = travis
+badges = appveyor
+
 [Prereqs / TestRequires]
 Plack                 = 1.0029
 HTTP::Cookies         = 0


### PR DESCRIPTION
This should do the trick to get the Travis and AppVeyor badges into the README (see also GH #12).  Unfortunately, I don't know exactly how you create the release branch, so my local tests might not accurately enough reproduce how things get built in the end.  However, I hope that this patch gets you most of the way to getting the badges into the GitHub README.