### PR TITLE
Remove commented-out `use` statement

### DIFF
--- a/t/02-configfile.t
+++ b/t/02-configfile.t
@@ -1,6 +1,5 @@
 use Test::More import => ['!pass'];
 use Test::Exception;
-#use Test::NoWarnings;
 
 use strict;
 use warnings;


### PR DESCRIPTION
The `use` statement for `Test::NoWarnings` is commented out.  Since the tests are passing fine, it's my guess that this code is no longer necessary and hence can be removed.