### PR TITLE
Use Perl shebang consistently in tests

### DIFF
--- a/t/01-session.t
+++ b/t/01-session.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use Test::More import => ['!pass'];
 use Test::Exception;
 use Test::NoWarnings;

--- a/t/02-configfile.t
+++ b/t/02-configfile.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use Test::More import => ['!pass'];
 use Test::Exception;
 #use Test::NoWarnings;

--- a/t/store-objects.t
+++ b/t/store-objects.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
While reading through the test files I noticed that some used a shebang line and others didn't.  This patch makes all test files use a consistent shebang line, based upon the shebang already present in some of the tests.