### PR TITLE
Use strict and warnings pragmas consistently in tests

### DIFF
--- a/t/01-session.t
+++ b/t/01-session.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More import => ['!pass'];
 use Test::Exception;
 use Test::NoWarnings;

--- a/t/02-configfile.t
+++ b/t/02-configfile.t
@@ -1,9 +1,10 @@
+use strict;
+use warnings;
+
 use Test::More import => ['!pass'];
 use Test::Exception;
 #use Test::NoWarnings;
 
-use strict;
-use warnings;
 use Dancer;
 use Dancer::ModuleLoader;
 use Dancer::Session::Cookie;

--- a/t/03-path.t
+++ b/t/03-path.t
@@ -1,9 +1,10 @@
 #!/usr/bin/env perl
 
-use Test::More import => ['!pass'];
-
 use strict;
 use warnings;
+
+use Test::More import => ['!pass'];
+
 use Dancer;
 
 my $CLASS = 'Dancer::Session::Cookie';

--- a/t/04-session_name.t
+++ b/t/04-session_name.t
@@ -1,9 +1,10 @@
 #!/usr/bin/env perl
 
-use Test::More import => ['!pass'];
-
 use strict;
 use warnings;
+
+use Test::More import => ['!pass'];
+
 use Dancer;
 
 my $CLASS = 'Dancer::Session::Cookie';


### PR DESCRIPTION
These commits ensure that a) strict and warnings pragams are present, and b) that they are always at the top of the test file so as to ensure a consistent structure in all test files.  This change also ensures that perlcritic doesn't complain about missing strict or warnings pragmas and thus allows the code to pass the perlcritic "gentle" severity.